### PR TITLE
Add option to re-prompt at intervals after user accept/ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ protected void onCreate(Bundle savedInstanceState) {
                                            *         setStoreType(Intent...) (Any custom intent/intents, Intent... - an intent or array of intents) */
       .setTimeToWait(Time.DAY, (short) 0) // default is 10 days, 0 means install millisecond, 10 means app is launched 10 or more time units later than installation
       .setLaunchTimes((byte) 3)           // default is 10, 3 means app is launched 3 or more times
+      .setTimeToReprompt(Time.MONTH, (short) 3) // default is off, 3 means prompt is shown again 3 months after last user accept/ignore action. Setting this value enables the check.
       .setRemindTimeToWait(Time.DAY, (short) 2) // default is 1 day, 1 means app is launched 1 or more time units after neutral button clicked
       .setRemindLaunchesNumber((byte) 1)  // default is 0, 1 means app is launched 1 or more times after neutral button clicked
       .setSelectedAppLaunches((byte) 1)   // default is 1, 1 means each launch, 2 means every 2nd launch, 3 means every 3rd launch, etc
@@ -165,6 +166,7 @@ Default options of the Rate Dialog are as below:
 10. Don't re-enable the Rate Dialog if a new version of app with different version name is installed. Change via `AppRate#setVersionNameCheck(boolean)`.
 11. Setting `AppRate#setDebug(boolean)` to `true` ensures that the Rate Dialog will be shown each time the app is launched. **This feature is for development only!**.
 12. There is no default callback when the button of Rate Dialog is pressed. Change via `AppRate.with(this).setOnClickButtonListener(OnClickButtonListener)`.
+13. Prompt is not shown again after user action (accept/ignore).
 
 ### OnClickButtonListener interface
 

--- a/library/src/main/java/com/vorlonsoft/android/rate/AppRate.java
+++ b/library/src/main/java/com/vorlonsoft/android/rate/AppRate.java
@@ -989,7 +989,7 @@ public final class AppRate {
             return false;
         }
 
-        return ((repromptDate == 0L)) || isOverDate(getLastAgreeShowFalseDate(context), repromptDate);
+        return (repromptDate == 0L) || isOverDate(getLastAgreeShowFalseDate(context), repromptDate);
     }
 
     private boolean isOverLaunchTimes() {

--- a/library/src/main/java/com/vorlonsoft/android/rate/PreferenceHelper.java
+++ b/library/src/main/java/com/vorlonsoft/android/rate/PreferenceHelper.java
@@ -40,6 +40,8 @@ final class PreferenceHelper {
 
     private static final String PREF_KEY_IS_AGREE_SHOW_DIALOG = "androidrate_is_agree_show_dialog";
 
+    private static final String PREF_KEY_LAST_AGREE_SHOW_FALSE_DATE = "androidrate_last_agree_show_false_date";
+
     private static final String PREF_KEY_LAUNCH_TIMES = "androidrate_launch_times";
 
     private static final String PREF_KEY_REMIND_INTERVAL = "androidrate_remind_interval";
@@ -216,10 +218,20 @@ final class PreferenceHelper {
         getPreferencesEditor(context)
                 .putBoolean(PREF_KEY_IS_AGREE_SHOW_DIALOG, isAgree)
                 .apply();
+
+        if (!isAgree) {
+            getPreferencesEditor(context)
+                    .putLong(PREF_KEY_LAST_AGREE_SHOW_FALSE_DATE, new Date().getTime())
+                    .apply();
+        }
     }
 
     static boolean getIsAgreeShowDialog(final Context context) {
         return getPreferences(context).getBoolean(PREF_KEY_IS_AGREE_SHOW_DIALOG, true);
+    }
+
+    static long getLastAgreeShowFalseDate(final Context context) {
+        return getPreferences(context).getLong(PREF_KEY_LAST_AGREE_SHOW_FALSE_DATE, 0L);
     }
 
     /**

--- a/sample/src/main/java/com/vorlonsoft/android/rate/sample/MainActivity.java
+++ b/sample/src/main/java/com/vorlonsoft/android/rate/sample/MainActivity.java
@@ -72,6 +72,7 @@ public class MainActivity extends AppCompatActivity {
                                                      *         setStoreType(Intent...) (Any custom intent/intents, Intent... - an intent or array of intents) */
                 .setTimeToWait(Time.DAY, (short) 3) // default is 10 days, 0 means install millisecond, 10 means app is launched 10 or more time units later than installation
                 .setLaunchTimes((byte) 10)          // default is 10, 3 means app is launched 3 or more times
+                .setTimeToReprompt(Time.MONTH, (short) 3) // default is off, 3 means prompt is shown again 3 months after last user accept/ignore action. Setting this value enables the check.
                 .setRemindTimeToWait(Time.DAY, (short) 2) // default is 1 day, 1 means app is launched 1 or more time units after neutral button clicked
                 .setRemindLaunchesNumber((byte) 1)  // default is 0, 1 means app is launched 1 or more times after neutral button clicked
                 .setSelectedAppLaunches((byte) 4)   // default is 1, 1 means each launch, 2 means every 2nd launch, 3 means every 3rd launch, etc


### PR DESCRIPTION
Allow the prompt to be shown again at intervals after each user action (accept/ignore).

Track the time each time the AgreeShowDialog preference is set to false. When checking if this value is false, `or` it with the result of `isOverLastAgreeShowFalseDate()` to determine if it has been X time units since AgreeShowDialog was set to false, a result of `true` will continue with the rest of the evaluation.

Defaults to off. Setting a time unit will turn the check on. Date of AgreeShowDialog = false is always tracked